### PR TITLE
Add API endpoint to retrieve Data Product by dataset and product IDs

### DIFF
--- a/.sqlx/query-cb0a0ba6c9a3b799b463c370fff66c9c73c03887fd93d657a89fa5e805b9cb30.json
+++ b/.sqlx/query-cb0a0ba6c9a3b799b463c370fff66c9c73c03887fd93d657a89fa5e805b9cb30.json
@@ -1,0 +1,119 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            data_product_id AS id,\n            compute AS \"compute: Compute\",\n            name,\n            version,\n            eager,\n            passthrough,\n            state AS \"state: State\",\n            run_id,\n            link,\n            passback,\n            extra,\n            modified_by,\n            modified_date\n        FROM\n            data_product\n        WHERE\n            dataset_id = $1\n            AND data_product_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "compute: Compute",
+        "type_info": {
+          "Custom": {
+            "name": "compute",
+            "kind": {
+              "Enum": [
+                "cams",
+                "dbxaas"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "eager",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "passthrough",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 6,
+        "name": "state: State",
+        "type_info": {
+          "Custom": {
+            "name": "state",
+            "kind": {
+              "Enum": [
+                "waiting",
+                "queued",
+                "running",
+                "success",
+                "failed",
+                "disabled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "run_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "link",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "passback",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "extra",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 11,
+        "name": "modified_by",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "modified_date",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "cb0a0ba6c9a3b799b463c370fff66c9c73c03887fd93d657a89fa5e805b9cb30"
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -460,12 +460,20 @@ mod tests {
         let json_value = test_json.value();
 
         // Validate the data product response
-        json_value.object().get("id").assert_string(&dp1_id.to_string());
+        json_value
+            .object()
+            .get("id")
+            .assert_string(&dp1_id.to_string());
         json_value.object().get("compute").assert_string("cams");
-        json_value.object().get("name").assert_string("data-product-1");
+        json_value
+            .object()
+            .get("name")
+            .assert_string("data-product-1");
         json_value.object().get("version").assert_string("1.0.0");
         json_value.object().get("eager").assert_bool(true);
-        json_value.object().get("passthrough")
+        json_value
+            .object()
+            .get("passthrough")
             .object()
             .get("test")
             .assert_string("passthrough1");
@@ -473,11 +481,16 @@ mod tests {
         json_value.object().get("run_id").assert_null();
         json_value.object().get("link").assert_null();
         json_value.object().get("passback").assert_null();
-        json_value.object().get("extra")
+        json_value
+            .object()
+            .get("extra")
             .object()
             .get("test")
             .assert_string("extra1");
-        json_value.object().get("modified_by").assert_string("placeholder_user");
+        json_value
+            .object()
+            .get("modified_by")
+            .assert_string("placeholder_user");
     }
 
     /// Test Data Product Get - Not Found Case
@@ -489,7 +502,9 @@ mod tests {
         let cli = TestClient::new(ep);
 
         let response: TestResponse = cli
-            .get(format!("/data_product/{non_existent_dataset_id}/{non_existent_data_product_id}"))
+            .get(format!(
+                "/data_product/{non_existent_dataset_id}/{non_existent_data_product_id}"
+            ))
             .data(pool)
             .send()
             .await;

--- a/src/api.rs
+++ b/src/api.rs
@@ -68,11 +68,11 @@ impl Api {
         // Start Transaction
         let mut tx = pool.begin().await.map_err(InternalServerError)?;
 
-        // Update data product states and return the updated plan
+        // Read the data product from the DB
         let data_product: DataProduct =
             data_product_read(&mut tx, dataset_id, data_product_id).await?;
 
-        // Commit Transaction
+        // Rollback transaction (read-only operation)
         tx.rollback().await.map_err(InternalServerError)?;
 
         Ok(Json(data_product))

--- a/src/core.rs
+++ b/src/core.rs
@@ -2181,7 +2181,6 @@ mod tests {
         // and disabled nodes are not considered in the DAG
         assert_eq!(plan.data_product(dp3_id).unwrap().state, State::Queued);
     }
-}
 
     // Tests for data_product_read function
 
@@ -2195,15 +2194,21 @@ mod tests {
         let added_plan = plan_add(&mut tx, &param, username).await.unwrap();
         let dataset_id = added_plan.dataset.id;
         let data_product_id = added_plan.data_products[0].id;
-        
+
         let result = data_product_read(&mut tx, dataset_id, data_product_id).await;
         assert!(result.is_ok());
 
         let read_data_product = result.unwrap();
         assert_eq!(read_data_product.id, data_product_id);
         assert_eq!(read_data_product.name, added_plan.data_products[0].name);
-        assert_eq!(read_data_product.compute, added_plan.data_products[0].compute);
-        assert_eq!(read_data_product.version, added_plan.data_products[0].version);
+        assert_eq!(
+            read_data_product.compute,
+            added_plan.data_products[0].compute
+        );
+        assert_eq!(
+            read_data_product.version,
+            added_plan.data_products[0].version
+        );
         assert_eq!(read_data_product.eager, added_plan.data_products[0].eager);
         assert_eq!(read_data_product.state, added_plan.data_products[0].state);
     }
@@ -2228,4 +2233,4 @@ mod tests {
             "no rows returned by a query that expected to return at least one row"
         );
     }
-
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -99,7 +99,7 @@ pub async fn plan_add(
     username: &str,
 ) -> poem::Result<Plan> {
     // Pull any prior details
-    let wip_plan = Plan::from_dataset_id(tx, param.dataset.id).await;
+    let wip_plan = Plan::from_db(tx, param.dataset.id).await;
 
     // So what did we get from the DB?
     let current_plan: Option<Plan> = match wip_plan {
@@ -127,7 +127,18 @@ pub async fn plan_add(
 
 /// Read a Plan Dag from the DB
 pub async fn plan_read(tx: &mut Transaction<'_, Postgres>, id: DatasetId) -> poem::Result<Plan> {
-    Plan::from_dataset_id(tx, id).await.map_err(to_poem_error)
+    Plan::from_db(tx, id).await.map_err(to_poem_error)
+}
+
+/// Read a Data Product from the DB
+pub async fn data_product_read(
+    tx: &mut Transaction<'_, Postgres>,
+    dataset_id: DatasetId,
+    data_product_id: DataProductId,
+) -> poem::Result<DataProduct> {
+    DataProduct::from_db(tx, dataset_id, data_product_id)
+        .await
+        .map_err(to_poem_error)
 }
 
 /// Update the state of our data product
@@ -304,7 +315,7 @@ pub async fn states_edit(
     }
 
     // Pull the Plan so we know what we are working with
-    let mut plan = Plan::from_dataset_id(tx, id).await.map_err(to_poem_error)?;
+    let mut plan = Plan::from_db(tx, id).await.map_err(to_poem_error)?;
 
     // Apply our updates to the data products
     for state in states {
@@ -332,7 +343,7 @@ pub async fn clear_edit(
     let modified_date: DateTime<Utc> = Utc::now();
 
     // Pull the Plan so we know what we are working with
-    let mut plan = Plan::from_dataset_id(tx, id).await.map_err(to_poem_error)?;
+    let mut plan = Plan::from_db(tx, id).await.map_err(to_poem_error)?;
 
     // Clear the data products
     for id in data_product_ids {
@@ -371,7 +382,7 @@ pub async fn disable_drop(
     let modified_date: DateTime<Utc> = Utc::now();
 
     // Pull the Plan so we know what we are working with
-    let mut plan = Plan::from_dataset_id(tx, id).await.map_err(to_poem_error)?;
+    let mut plan = Plan::from_db(tx, id).await.map_err(to_poem_error)?;
 
     for id in data_product_ids {
         // Pull the Data Product we want

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,8 +1,8 @@
 use crate::{
     error::Result,
     model::{
-        Compute, DataProduct, DataProductParam, Dataset, DatasetId, DatasetParam, Dependency,
-        DependencyParam, State, StateParam,
+        Compute, DataProduct, DataProductId, DataProductParam, Dataset, DatasetId, DatasetParam,
+        Dependency, DependencyParam, State, StateParam,
     },
 };
 use chrono::{DateTime, Utc};
@@ -209,6 +209,42 @@ pub async fn state_update(
         param.passback,
         username,
         modified_date,
+    )
+    .fetch_one(&mut **tx)
+    .await?;
+
+    Ok(data_product)
+}
+
+/// Retrieve a Data Product
+pub async fn data_product_select(
+    tx: &mut Transaction<'_, Postgres>,
+    dataset_id: DatasetId,
+    data_product_id: DataProductId,
+) -> Result<DataProduct> {
+    let data_product = query_as!(
+        DataProduct,
+        r#"SELECT
+            data_product_id AS id,
+            compute AS "compute: Compute",
+            name,
+            version,
+            eager,
+            passthrough,
+            state AS "state: State",
+            run_id,
+            link,
+            passback,
+            extra,
+            modified_by,
+            modified_date
+        FROM
+            data_product
+        WHERE
+            dataset_id = $1
+            AND data_product_id = $2"#,
+        dataset_id,
+        data_product_id,
     )
     .fetch_one(&mut **tx)
     .await?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -579,18 +579,18 @@ mod tests {
         let expected_data_product = &inserted_plan.data_products[0];
 
         // Test: Can we read a data product record from the DB?
-        let retrieved_data_product = DataProduct::from_db(
-            &mut tx,
-            inserted_plan.dataset.id,
-            expected_data_product.id,
-        )
-        .await
-        .unwrap();
+        let retrieved_data_product =
+            DataProduct::from_db(&mut tx, inserted_plan.dataset.id, expected_data_product.id)
+                .await
+                .unwrap();
 
         assert_eq!(retrieved_data_product, *expected_data_product);
         assert_eq!(retrieved_data_product.id, expected_data_product.id);
         assert_eq!(retrieved_data_product.name, expected_data_product.name);
-        assert_eq!(retrieved_data_product.compute, expected_data_product.compute);
+        assert_eq!(
+            retrieved_data_product.compute,
+            expected_data_product.compute
+        );
         assert_eq!(retrieved_data_product.state, expected_data_product.state);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new API endpoint to retrieve a single data product by dataset and data product IDs.
* **Improvements**
  * Updated API documentation tags for better organization.
  * Simplified the URL for disabling data products.
* **Refactor**
  * Standardized internal methods for loading plans and data products to improve consistency.
  * Added new database query and data product retrieval methods to support the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->