### PR TITLE
Add explicit pause and unpause endpoints for plans and update related logic

### DIFF
--- a/.sqlx/query-6ede60d31bd6b9f35b117ea7f0388cd77b461a05f46ea853b42d8b51d709040e.json
+++ b/.sqlx/query-6ede60d31bd6b9f35b117ea7f0388cd77b461a05f46ea853b42d8b51d709040e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "INSERT INTO dataset (\n            dataset_id,\n            paused,\n            extra,\n            modified_by,\n            modified_date\n        ) VALUES (\n            $1,\n            $2,\n            $3,\n            $4,\n            $5\n        ) ON CONFLICT (dataset_id) DO\n        UPDATE SET\n            paused = $2,\n            extra = $3,\n            modified_by = $4,\n            modified_date = $5\n        RETURNING\n            dataset_id AS id,\n            paused,\n            extra,\n            modified_by,\n            modified_date",
+  "query": "INSERT INTO dataset (\n            dataset_id,\n            paused,\n            extra,\n            modified_by,\n            modified_date\n        ) VALUES (\n            $1,\n            false,\n            $2,\n            $3,\n            $4\n        ) ON CONFLICT (dataset_id) DO\n        UPDATE SET\n            extra = $2,\n            modified_by = $3,\n            modified_date = $4\n        RETURNING\n            dataset_id AS id,\n            paused,\n            extra,\n            modified_by,\n            modified_date",
   "describe": {
     "columns": [
       {
@@ -32,7 +32,6 @@
     "parameters": {
       "Left": [
         "Uuid",
-        "Bool",
         "Jsonb",
         "Text",
         "Timestamptz"
@@ -46,5 +45,5 @@
       false
     ]
   },
-  "hash": "d9b0be7a437d0513b31c42b673b50d0acb34f1cb7ef30398a11dc182a364a15d"
+  "hash": "6ede60d31bd6b9f35b117ea7f0388cd77b461a05f46ea853b42d8b51d709040e"
 }

--- a/.sqlx/query-9873a0f7a9be4118c80dc67e62ca1193614fb38cce064b281249089c06c631a3.json
+++ b/.sqlx/query-9873a0f7a9be4118c80dc67e62ca1193614fb38cce064b281249089c06c631a3.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE\n            dataset\n        SET\n            paused = $2,\n            modified_by = $3,\n            modified_date = $4\n        WHERE\n            dataset_id = $1\n        RETURNING\n            dataset_id AS id,\n            paused,\n            extra,\n            modified_by,\n            modified_date",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "paused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 2,
+        "name": "extra",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "modified_by",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "modified_date",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool",
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "9873a0f7a9be4118c80dc67e62ca1193614fb38cce064b281249089c06c631a3"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -981,9 +981,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1225,9 +1225,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "parking"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1325,4 +1325,57 @@ mod tests {
             .assert_text(format!("Data product is locked: {dp1_id}"))
             .await;
     }
+
+    /// Test Plan Pause Put - Success Case
+    #[sqlx::test]
+    async fn test_plan_pause_put_success(pool: PgPool) {
+        let dataset_id = Uuid::new_v4();
+        let dp1_id = Uuid::new_v4();
+        let dp2_id = Uuid::new_v4();
+
+        // Create initial plan (unpaused by default)
+        let create_param = create_test_plan_param(dataset_id, dp1_id, dp2_id);
+
+        let ep = OpenApiService::new(Api, "test", "1.0");
+        let cli = TestClient::new(ep);
+
+        // Create the plan first
+        let create_response: TestResponse = cli
+            .post("/plan")
+            .header("Content-Type", "application/json; charset=utf-8")
+            .body_json(&create_param)
+            .data(pool.clone())
+            .send()
+            .await;
+        create_response.assert_status_is_ok();
+
+        // Verify plan is initially unpaused
+        let initial_json = create_response.json().await;
+        let initial_value = initial_json.value();
+        initial_value
+            .object()
+            .get("dataset")
+            .object()
+            .get("paused")
+            .assert_bool(false);
+
+        // Test pause endpoint
+        let pause_response: TestResponse = cli
+            .put(format!("/plan/pause/{dataset_id}"))
+            .header("Content-Type", "application/json; charset=utf-8")
+            .data(pool)
+            .send()
+            .await;
+        pause_response.assert_status_is_ok();
+
+        // Verify plan is now paused
+        let pause_json = pause_response.json().await;
+        let pause_value = pause_json.value();
+        pause_value
+            .object()
+            .get("dataset")
+            .object()
+            .get("paused")
+            .assert_bool(true);
+    }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -73,7 +73,7 @@ impl Api {
         // Pause a Plan
         let plan: Plan = plan_pause_edit(&mut tx, dataset_id, true, "placeholder_user").await?;
 
-        // Commit transaction (read-only operation)
+        // Commit transaction
         tx.commit().await.map_err(InternalServerError)?;
 
         Ok(Json(plan))
@@ -89,10 +89,10 @@ impl Api {
         // Start Transaction
         let mut tx = pool.begin().await.map_err(InternalServerError)?;
 
-        // Pause a Plan
+        // Unpause a Plan
         let plan: Plan = plan_pause_edit(&mut tx, dataset_id, false, "placeholder_user").await?;
 
-        // Commit transaction (read-only operation)
+        // Commit transaction
         tx.commit().await.map_err(InternalServerError)?;
 
         Ok(Json(plan))

--- a/src/api.rs
+++ b/src/api.rs
@@ -1401,6 +1401,17 @@ mod tests {
             .await;
         create_response.assert_status_is_ok();
 
+        // Verify the plan is unpaused
+        let create_json = create_response.json().await;
+        let create_value = create_json.value();
+
+        create_value
+            .object()
+            .get("dataset")
+            .object()
+            .get("paused")
+            .assert_bool(false);
+
         // First pause the plan
         let pause_response: TestResponse = cli
             .put(format!("/plan/pause/{dataset_id}"))

--- a/src/core.rs
+++ b/src/core.rs
@@ -17,7 +17,7 @@ fn to_poem_error(err: Error) -> poem::Error {
         Error::Cyclical => UnprocessableEntity(err),
         // Failed to build graph
         Error::Graph(error) => InternalServerError(error),
-        // Already disired pause state
+        // Already desired pause state
         Error::Pause(_, _) => BadRequest(err),
         // Row not found
         Error::Sqlx(sqlx::Error::RowNotFound) => NotFound(sqlx::Error::RowNotFound),

--- a/src/core.rs
+++ b/src/core.rs
@@ -2265,7 +2265,9 @@ mod tests {
         assert!(format!("{err}").contains("pause state is already set to: false"));
 
         // First pause the plan
-        let paused_plan = plan_pause_edit(&mut tx, dataset_id, true, username).await.unwrap();
+        let paused_plan = plan_pause_edit(&mut tx, dataset_id, true, username)
+            .await
+            .unwrap();
         assert!(paused_plan.dataset.paused);
 
         // Try to pause it again
@@ -2354,12 +2356,20 @@ mod tests {
         .unwrap();
 
         // Pause the plan
-        let paused_plan = plan_pause_edit(&mut tx, dataset_id, true, username).await.unwrap();
+        let paused_plan = plan_pause_edit(&mut tx, dataset_id, true, username)
+            .await
+            .unwrap();
         assert!(paused_plan.dataset.paused);
 
         // Children should remain in waiting state even though parent is successful
-        assert_eq!(paused_plan.data_product(dp2_id).unwrap().state, State::Waiting);
-        assert_eq!(paused_plan.data_product(dp3_id).unwrap().state, State::Waiting);
+        assert_eq!(
+            paused_plan.data_product(dp2_id).unwrap().state,
+            State::Waiting
+        );
+        assert_eq!(
+            paused_plan.data_product(dp3_id).unwrap().state,
+            State::Waiting
+        );
     }
 
     /// Test plan_pause_edit - when unpaused, downstream tasks enter queued state
@@ -2449,12 +2459,20 @@ mod tests {
         assert_eq!(plan.data_product(dp3_id).unwrap().state, State::Waiting);
 
         // Now unpause the plan
-        let unpaused_plan = plan_pause_edit(&mut tx, dataset_id, false, username).await.unwrap();
+        let unpaused_plan = plan_pause_edit(&mut tx, dataset_id, false, username)
+            .await
+            .unwrap();
         assert!(!unpaused_plan.dataset.paused);
 
         // Children should now be queued since parent is successful and plan is unpaused
-        assert_eq!(unpaused_plan.data_product(dp2_id).unwrap().state, State::Queued);
-        assert_eq!(unpaused_plan.data_product(dp3_id).unwrap().state, State::Queued);
+        assert_eq!(
+            unpaused_plan.data_product(dp2_id).unwrap().state,
+            State::Queued
+        );
+        assert_eq!(
+            unpaused_plan.data_product(dp3_id).unwrap().state,
+            State::Queued
+        );
     }
 
     /// Test plan_pause_edit returns error for non-existent plan

--- a/src/db.rs
+++ b/src/db.rs
@@ -16,6 +16,7 @@ pub async fn dataset_upsert(
     username: &str,
     modified_date: DateTime<Utc>,
 ) -> Result<Dataset> {
+    // Default to pause to false for new dataseets
     let dataset = query_as!(
         Dataset,
         "INSERT INTO dataset (
@@ -26,16 +27,15 @@ pub async fn dataset_upsert(
             modified_date
         ) VALUES (
             $1,
+            false,
             $2,
             $3,
-            $4,
-            $5
+            $4
         ) ON CONFLICT (dataset_id) DO
         UPDATE SET
-            paused = $2,
-            extra = $3,
-            modified_by = $4,
-            modified_date = $5
+            extra = $2,
+            modified_by = $3,
+            modified_date = $4
         RETURNING
             dataset_id AS id,
             paused,
@@ -43,7 +43,6 @@ pub async fn dataset_upsert(
             modified_by,
             modified_date",
         param.id,
-        param.paused,
         param.extra,
         username,
         modified_date,
@@ -73,6 +72,41 @@ pub async fn dataset_select(
         WHERE
             dataset_id = $1",
         dataset_id,
+    )
+    .fetch_one(&mut **tx)
+    .await?;
+
+    Ok(dataset)
+}
+
+/// Pause / Un-pause a dataset
+pub async fn dataset_pause_update(
+    tx: &mut Transaction<'_, Postgres>,
+    dataset_id: DatasetId,
+    paused: bool,
+    username: &str,
+    modified_date: DateTime<Utc>,
+) -> Result<Dataset> {
+    let dataset = query_as!(
+        Dataset,
+        "UPDATE
+            dataset
+        SET
+            paused = $2,
+            modified_by = $3,
+            modified_date = $4
+        WHERE
+            dataset_id = $1
+        RETURNING
+            dataset_id AS id,
+            paused,
+            extra,
+            modified_by,
+            modified_date",
+        dataset_id,
+        paused,
+        username,
+        modified_date,
     )
     .fetch_one(&mut **tx)
     .await?;
@@ -380,7 +414,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Inputs
-        let param: DatasetParam = Default::default();
+        let param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -394,7 +428,7 @@ pub mod tests {
             dataset,
             Dataset {
                 id: param.id,
-                paused: param.paused,
+                paused: false,
                 extra: param.extra,
                 modified_by: username.to_string(),
                 modified_date: trim_to_microseconds(modified_date),
@@ -408,7 +442,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Inputs
-        let mut param: DatasetParam = Default::default();
+        let param = DatasetParam::default();
         let username = "test";
         let mut modified_date = Utc::now();
 
@@ -418,7 +452,6 @@ pub mod tests {
             .unwrap();
 
         // Update parameters
-        param.paused = true;
         modified_date = Utc::now();
 
         // Update to new values
@@ -431,7 +464,7 @@ pub mod tests {
             dataset,
             Dataset {
                 id: param.id,
-                paused: param.paused,
+                paused: false,
                 extra: param.extra,
                 modified_by: username.to_string(),
                 modified_date: trim_to_microseconds(modified_date),
@@ -444,7 +477,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Inputs
-        let param: DatasetParam = Default::default();
+        let param = DatasetParam::default();
         let username = "test_user";
         let modified_date = Utc::now();
 
@@ -462,7 +495,7 @@ pub mod tests {
             selected_dataset,
             Dataset {
                 id: param.id,
-                paused: param.paused,
+                paused: false,
                 extra: param.extra,
                 modified_by: username.to_string(),
                 modified_date: trim_to_microseconds(modified_date),
@@ -495,7 +528,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // First create a dataset since data_product has a foreign key constraint
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -504,7 +537,7 @@ pub mod tests {
             .unwrap();
 
         // Now create the data product
-        let data_product_param: DataProductParam = Default::default();
+        let data_product_param = DataProductParam::default();
 
         // Test our function
         let data_product = data_product_upsert(
@@ -545,7 +578,7 @@ pub mod tests {
 
         // Create data product with a fake dataset_id
         let fake_dataset_id = Uuid::new_v4();
-        let data_product_param: DataProductParam = Default::default();
+        let data_product_param = DataProductParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -573,7 +606,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // First create a dataset
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -582,7 +615,7 @@ pub mod tests {
             .unwrap();
 
         // Create a data product
-        let data_product_param: DataProductParam = Default::default();
+        let data_product_param = DataProductParam::default();
 
         let inserted_data_product = data_product_upsert(
             &mut tx,
@@ -648,7 +681,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // First create a dataset
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -657,7 +690,7 @@ pub mod tests {
             .unwrap();
 
         // Create initial data product
-        let initial_param: DataProductParam = Default::default();
+        let initial_param = DataProductParam::default();
 
         data_product_upsert(&mut tx, dataset.id, &initial_param, username, modified_date)
             .await
@@ -715,7 +748,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // First create a dataset
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -724,7 +757,7 @@ pub mod tests {
             .unwrap();
 
         // Create initial data product
-        let data_product_param: DataProductParam = Default::default();
+        let data_product_param = DataProductParam::default();
 
         let initial_data_product = data_product_upsert(
             &mut tx,
@@ -782,7 +815,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Create a dataset so dataset exists but no data product
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -816,7 +849,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Create a dataset
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -825,7 +858,7 @@ pub mod tests {
             .unwrap();
 
         // Create multiple data products for this dataset
-        let data_product_1: DataProductParam = Default::default();
+        let data_product_1 = DataProductParam::default();
         let data_product_2 = DataProductParam {
             compute: Compute::Dbxaas,
             name: "data-product-2".to_string(),
@@ -873,7 +906,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Create a dataset
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -882,7 +915,7 @@ pub mod tests {
             .unwrap();
 
         // Create two data products to create a dependency between them
-        let parent_param: DataProductParam = Default::default();
+        let parent_param = DataProductParam::default();
         let child_param = DataProductParam {
             compute: Compute::Dbxaas,
             name: "child-data-product".to_string(),
@@ -936,7 +969,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Create a dataset
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -945,7 +978,7 @@ pub mod tests {
             .unwrap();
 
         // Create two data products
-        let parent_param: DataProductParam = Default::default();
+        let parent_param = DataProductParam::default();
         let child_param = DataProductParam {
             compute: Compute::Dbxaas,
             name: "child-data-product".to_string(),
@@ -1019,7 +1052,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Create a dataset
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -1028,7 +1061,7 @@ pub mod tests {
             .unwrap();
 
         // Create only a child data product (no parent)
-        let child_param: DataProductParam = Default::default();
+        let child_param = DataProductParam::default();
 
         let child_dp =
             data_product_upsert(&mut tx, dataset.id, &child_param, username, modified_date)
@@ -1066,7 +1099,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Create a dataset
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -1075,7 +1108,7 @@ pub mod tests {
             .unwrap();
 
         // Create only a parent data product (no child)
-        let parent_param: DataProductParam = Default::default();
+        let parent_param = DataProductParam::default();
 
         let parent_dp =
             data_product_upsert(&mut tx, dataset.id, &parent_param, username, modified_date)
@@ -1113,7 +1146,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Create a dataset
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 
@@ -1122,7 +1155,7 @@ pub mod tests {
             .unwrap();
 
         // Create a data product
-        let data_product_param: DataProductParam = Default::default();
+        let data_product_param = DataProductParam::default();
 
         let data_product = data_product_upsert(
             &mut tx,
@@ -1165,7 +1198,7 @@ pub mod tests {
         let mut tx = pool.begin().await.unwrap();
 
         // Create a dataset
-        let dataset_param: DatasetParam = Default::default();
+        let dataset_param = DatasetParam::default();
         let username = "test";
         let modified_date = Utc::now();
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1276,135 +1276,135 @@ pub mod tests {
         assert_eq!(retrieved_dependencies.len(), 2);
         assert!(retrieved_dependencies.contains(&dep1));
         assert!(retrieved_dependencies.contains(&dep2));
+    }
 
-        /// Test dataset_pause_update setting pause to true
-        #[sqlx::test]
-        async fn test_dataset_pause_update_to_true(pool: PgPool) {
-            let mut tx = pool.begin().await.unwrap();
+    /// Test dataset_pause_update setting pause to true
+    #[sqlx::test]
+    async fn test_dataset_pause_update_to_true(pool: PgPool) {
+        let mut tx = pool.begin().await.unwrap();
 
-            // First create a dataset
-            let param = DatasetParam::default();
-            let username = "test";
-            let modified_date = Utc::now();
+        // First create a dataset
+        let param = DatasetParam::default();
+        let username = "test";
+        let modified_date = Utc::now();
 
-            let dataset = dataset_upsert(&mut tx, &param, username, modified_date)
-                .await
-                .unwrap();
-
-            // Verify dataset starts as not paused
-            assert_eq!(dataset.paused, false);
-
-            // Now pause the dataset
-            let pause_username = "pause_user";
-            let pause_modified_date = Utc::now();
-
-            let paused_dataset = dataset_pause_update(
-                &mut tx,
-                dataset.id,
-                true,
-                pause_username,
-                pause_modified_date,
-            )
+        let dataset = dataset_upsert(&mut tx, &param, username, modified_date)
             .await
             .unwrap();
 
-            // Verify the dataset is now paused
-            assert_eq!(
-                paused_dataset,
-                Dataset {
-                    id: dataset.id,
-                    paused: true,
-                    extra: dataset.extra,
-                    modified_by: pause_username.to_string(),
-                    modified_date: trim_to_microseconds(pause_modified_date),
-                }
-            );
-        }
+        // Verify dataset starts as not paused
+        assert_eq!(dataset.paused, false);
 
-        /// Test dataset_pause_update setting pause to false
-        #[sqlx::test]
-        async fn test_dataset_pause_update_to_false(pool: PgPool) {
-            let mut tx = pool.begin().await.unwrap();
+        // Now pause the dataset
+        let pause_username = "pause_user";
+        let pause_modified_date = Utc::now();
 
-            // First create a dataset
-            let param = DatasetParam::default();
-            let username = "test";
-            let modified_date = Utc::now();
+        let paused_dataset = dataset_pause_update(
+            &mut tx,
+            dataset.id,
+            true,
+            pause_username,
+            pause_modified_date,
+        )
+        .await
+        .unwrap();
 
-            let dataset = dataset_upsert(&mut tx, &param, username, modified_date)
-                .await
-                .unwrap();
+        // Verify the dataset is now paused
+        assert_eq!(
+            paused_dataset,
+            Dataset {
+                id: dataset.id,
+                paused: true,
+                extra: dataset.extra,
+                modified_by: pause_username.to_string(),
+                modified_date: trim_to_microseconds(pause_modified_date),
+            }
+        );
+    }
 
-            // First pause the dataset
-            let pause_username = "pause_user";
-            let pause_modified_date = Utc::now();
+    /// Test dataset_pause_update setting pause to false
+    #[sqlx::test]
+    async fn test_dataset_pause_update_to_false(pool: PgPool) {
+        let mut tx = pool.begin().await.unwrap();
 
-            let paused_dataset = dataset_pause_update(
-                &mut tx,
-                dataset.id,
-                true,
-                pause_username,
-                pause_modified_date,
-            )
+        // First create a dataset
+        let param = DatasetParam::default();
+        let username = "test";
+        let modified_date = Utc::now();
+
+        let dataset = dataset_upsert(&mut tx, &param, username, modified_date)
             .await
             .unwrap();
 
-            // Verify it's paused
-            assert_eq!(paused_dataset.paused, true);
+        // First pause the dataset
+        let pause_username = "pause_user";
+        let pause_modified_date = Utc::now();
 
-            // Now unpause the dataset
-            let unpause_username = "unpause_user";
-            let unpause_modified_date = Utc::now();
+        let paused_dataset = dataset_pause_update(
+            &mut tx,
+            dataset.id,
+            true,
+            pause_username,
+            pause_modified_date,
+        )
+        .await
+        .unwrap();
 
-            let unpaused_dataset = dataset_pause_update(
-                &mut tx,
-                dataset.id,
-                false,
-                unpause_username,
-                unpause_modified_date,
-            )
-            .await
-            .unwrap();
+        // Verify it's paused
+        assert_eq!(paused_dataset.paused, true);
 
-            // Verify the dataset is now unpaused
-            assert_eq!(
-                unpaused_dataset,
-                Dataset {
-                    id: dataset.id,
-                    paused: false,
-                    extra: dataset.extra,
-                    modified_by: unpause_username.to_string(),
-                    modified_date: trim_to_microseconds(unpause_modified_date),
-                }
-            );
-        }
+        // Now unpause the dataset
+        let unpause_username = "unpause_user";
+        let unpause_modified_date = Utc::now();
 
-        /// Test dataset_pause_update with nonexistent dataset returns error
-        #[sqlx::test]
-        async fn test_dataset_pause_update_nonexistent(pool: PgPool) {
-            let mut tx = pool.begin().await.unwrap();
+        let unpaused_dataset = dataset_pause_update(
+            &mut tx,
+            dataset.id,
+            false,
+            unpause_username,
+            unpause_modified_date,
+        )
+        .await
+        .unwrap();
 
-            // Generate a random UUID that doesn't exist in the database
-            let nonexistent_dataset_id = Uuid::new_v4();
-            let username = "test";
-            let modified_date = Utc::now();
+        // Verify the dataset is now unpaused
+        assert_eq!(
+            unpaused_dataset,
+            Dataset {
+                id: dataset.id,
+                paused: false,
+                extra: dataset.extra,
+                modified_by: unpause_username.to_string(),
+                modified_date: trim_to_microseconds(unpause_modified_date),
+            }
+        );
+    }
 
-            // Test that dataset_pause_update returns an error for non-existent dataset
-            let result = dataset_pause_update(
-                &mut tx,
-                nonexistent_dataset_id,
-                true,
-                username,
-                modified_date,
-            )
-            .await;
+    /// Test dataset_pause_update with nonexistent dataset returns error
+    #[sqlx::test]
+    async fn test_dataset_pause_update_nonexistent(pool: PgPool) {
+        let mut tx = pool.begin().await.unwrap();
 
-            // Assert that we got the error we wanted
-            assert!(result.is_err());
-            assert!(matches!(
-                result.unwrap_err(),
-                Error::Sqlx(sqlx::Error::RowNotFound),
-            ));
-        }
+        // Generate a random UUID that doesn't exist in the database
+        let nonexistent_dataset_id = Uuid::new_v4();
+        let username = "test";
+        let modified_date = Utc::now();
+
+        // Test that dataset_pause_update returns an error for non-existent dataset
+        let result = dataset_pause_update(
+            &mut tx,
+            nonexistent_dataset_id,
+            true,
+            username,
+            modified_date,
+        )
+        .await;
+
+        // Assert that we got the error we wanted
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            Error::Sqlx(sqlx::Error::RowNotFound),
+        ));
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -16,7 +16,7 @@ pub async fn dataset_upsert(
     username: &str,
     modified_date: DateTime<Utc>,
 ) -> Result<Dataset> {
-    // Default to pause to false for new dataseets
+    // Default paused to false for new datasets
     let dataset = query_as!(
         Dataset,
         "INSERT INTO dataset (

--- a/src/db.rs
+++ b/src/db.rs
@@ -1277,134 +1277,134 @@ pub mod tests {
         assert!(retrieved_dependencies.contains(&dep1));
         assert!(retrieved_dependencies.contains(&dep2));
 
-    /// Test dataset_pause_update setting pause to true
-    #[sqlx::test]
-    async fn test_dataset_pause_update_to_true(pool: PgPool) {
-        let mut tx = pool.begin().await.unwrap();
+        /// Test dataset_pause_update setting pause to true
+        #[sqlx::test]
+        async fn test_dataset_pause_update_to_true(pool: PgPool) {
+            let mut tx = pool.begin().await.unwrap();
 
-        // First create a dataset
-        let param = DatasetParam::default();
-        let username = "test";
-        let modified_date = Utc::now();
+            // First create a dataset
+            let param = DatasetParam::default();
+            let username = "test";
+            let modified_date = Utc::now();
 
-        let dataset = dataset_upsert(&mut tx, &param, username, modified_date)
+            let dataset = dataset_upsert(&mut tx, &param, username, modified_date)
+                .await
+                .unwrap();
+
+            // Verify dataset starts as not paused
+            assert_eq!(dataset.paused, false);
+
+            // Now pause the dataset
+            let pause_username = "pause_user";
+            let pause_modified_date = Utc::now();
+
+            let paused_dataset = dataset_pause_update(
+                &mut tx,
+                dataset.id,
+                true,
+                pause_username,
+                pause_modified_date,
+            )
             .await
             .unwrap();
 
-        // Verify dataset starts as not paused
-        assert_eq!(dataset.paused, false);
+            // Verify the dataset is now paused
+            assert_eq!(
+                paused_dataset,
+                Dataset {
+                    id: dataset.id,
+                    paused: true,
+                    extra: dataset.extra,
+                    modified_by: pause_username.to_string(),
+                    modified_date: trim_to_microseconds(pause_modified_date),
+                }
+            );
+        }
 
-        // Now pause the dataset
-        let pause_username = "pause_user";
-        let pause_modified_date = Utc::now();
+        /// Test dataset_pause_update setting pause to false
+        #[sqlx::test]
+        async fn test_dataset_pause_update_to_false(pool: PgPool) {
+            let mut tx = pool.begin().await.unwrap();
 
-        let paused_dataset = dataset_pause_update(
-            &mut tx,
-            dataset.id,
-            true,
-            pause_username,
-            pause_modified_date,
-        )
-        .await
-        .unwrap();
+            // First create a dataset
+            let param = DatasetParam::default();
+            let username = "test";
+            let modified_date = Utc::now();
 
-        // Verify the dataset is now paused
-        assert_eq!(
-            paused_dataset,
-            Dataset {
-                id: dataset.id,
-                paused: true,
-                extra: dataset.extra,
-                modified_by: pause_username.to_string(),
-                modified_date: trim_to_microseconds(pause_modified_date),
-            }
-        );
-    }
+            let dataset = dataset_upsert(&mut tx, &param, username, modified_date)
+                .await
+                .unwrap();
 
-    /// Test dataset_pause_update setting pause to false
-    #[sqlx::test]
-    async fn test_dataset_pause_update_to_false(pool: PgPool) {
-        let mut tx = pool.begin().await.unwrap();
+            // First pause the dataset
+            let pause_username = "pause_user";
+            let pause_modified_date = Utc::now();
 
-        // First create a dataset
-        let param = DatasetParam::default();
-        let username = "test";
-        let modified_date = Utc::now();
-
-        let dataset = dataset_upsert(&mut tx, &param, username, modified_date)
+            let paused_dataset = dataset_pause_update(
+                &mut tx,
+                dataset.id,
+                true,
+                pause_username,
+                pause_modified_date,
+            )
             .await
             .unwrap();
 
-        // First pause the dataset
-        let pause_username = "pause_user";
-        let pause_modified_date = Utc::now();
+            // Verify it's paused
+            assert_eq!(paused_dataset.paused, true);
 
-        let paused_dataset = dataset_pause_update(
-            &mut tx,
-            dataset.id,
-            true,
-            pause_username,
-            pause_modified_date,
-        )
-        .await
-        .unwrap();
+            // Now unpause the dataset
+            let unpause_username = "unpause_user";
+            let unpause_modified_date = Utc::now();
 
-        // Verify it's paused
-        assert_eq!(paused_dataset.paused, true);
+            let unpaused_dataset = dataset_pause_update(
+                &mut tx,
+                dataset.id,
+                false,
+                unpause_username,
+                unpause_modified_date,
+            )
+            .await
+            .unwrap();
 
-        // Now unpause the dataset
-        let unpause_username = "unpause_user";
-        let unpause_modified_date = Utc::now();
+            // Verify the dataset is now unpaused
+            assert_eq!(
+                unpaused_dataset,
+                Dataset {
+                    id: dataset.id,
+                    paused: false,
+                    extra: dataset.extra,
+                    modified_by: unpause_username.to_string(),
+                    modified_date: trim_to_microseconds(unpause_modified_date),
+                }
+            );
+        }
 
-        let unpaused_dataset = dataset_pause_update(
-            &mut tx,
-            dataset.id,
-            false,
-            unpause_username,
-            unpause_modified_date,
-        )
-        .await
-        .unwrap();
+        /// Test dataset_pause_update with nonexistent dataset returns error
+        #[sqlx::test]
+        async fn test_dataset_pause_update_nonexistent(pool: PgPool) {
+            let mut tx = pool.begin().await.unwrap();
 
-        // Verify the dataset is now unpaused
-        assert_eq!(
-            unpaused_dataset,
-            Dataset {
-                id: dataset.id,
-                paused: false,
-                extra: dataset.extra,
-                modified_by: unpause_username.to_string(),
-                modified_date: trim_to_microseconds(unpause_modified_date),
-            }
-        );
-    }
+            // Generate a random UUID that doesn't exist in the database
+            let nonexistent_dataset_id = Uuid::new_v4();
+            let username = "test";
+            let modified_date = Utc::now();
 
-    /// Test dataset_pause_update with nonexistent dataset returns error
-    #[sqlx::test]
-    async fn test_dataset_pause_update_nonexistent(pool: PgPool) {
-        let mut tx = pool.begin().await.unwrap();
+            // Test that dataset_pause_update returns an error for non-existent dataset
+            let result = dataset_pause_update(
+                &mut tx,
+                nonexistent_dataset_id,
+                true,
+                username,
+                modified_date,
+            )
+            .await;
 
-        // Generate a random UUID that doesn't exist in the database
-        let nonexistent_dataset_id = Uuid::new_v4();
-        let username = "test";
-        let modified_date = Utc::now();
-
-        // Test that dataset_pause_update returns an error for non-existent dataset
-        let result = dataset_pause_update(
-            &mut tx,
-            nonexistent_dataset_id,
-            true,
-            username,
-            modified_date,
-        )
-        .await;
-
-        // Assert that we got the error we wanted
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            Error::Sqlx(sqlx::Error::RowNotFound),
-        ));
-    }
+            // Assert that we got the error we wanted
+            assert!(result.is_err());
+            assert!(matches!(
+                result.unwrap_err(),
+                Error::Sqlx(sqlx::Error::RowNotFound),
+            ));
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,10 @@ pub enum Error {
     #[error("Data product not found for: {0}")]
     Missing(DataProductId),
 
+    /// Dataset Pause error
+    #[error("Dataset '{0}' pause state is already set to: {1}")]
+    Pause(DataProductId, bool),
+
     /// Errors from SQLx
     #[error("Error from SQLx: {0}")]
     Sqlx(#[from] sqlx::Error),

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,10 +1,11 @@
 use crate::{
     dag::Dag,
     db::{
-        data_product_select, data_product_upsert, data_products_by_dataset_select, dataset_select,
-        dataset_upsert, dependencies_by_dataset_select, dependency_upsert, state_update,
+        data_product_select, data_product_upsert, data_products_by_dataset_select,
+        dataset_pause_update, dataset_select, dataset_upsert, dependencies_by_dataset_select,
+        dependency_upsert, state_update,
     },
-    error::Result,
+    error::{Error, Result},
 };
 use chrono::{DateTime, Utc};
 use petgraph::graph::DiGraph;
@@ -104,6 +105,26 @@ impl Plan {
 
         // Build the dag
         DiGraph::<DataProductId, u32>::build_dag(data_product_ids, edges)
+    }
+
+    /// Pause / Unpause a Plan
+    pub async fn paused(
+        &mut self,
+        tx: &mut Transaction<'_, Postgres>,
+        paused: bool,
+        username: &str,
+        modified_date: DateTime<Utc>,
+    ) -> Result<()> {
+        // Check is already desired state
+        if self.dataset.paused == paused {
+            return Err(Error::Pause(self.dataset.id, paused));
+        }
+
+        // Set the paused state
+        self.dataset =
+            dataset_pause_update(tx, self.dataset.id, paused, username, modified_date).await?;
+
+        Ok(())
     }
 }
 
@@ -313,7 +334,6 @@ impl PlanParam {
 #[derive(Clone, Object)]
 pub struct DatasetParam {
     pub id: DatasetId,
-    pub paused: bool,
     pub extra: Option<Value>,
 }
 
@@ -406,7 +426,6 @@ mod tests {
         fn default() -> Self {
             Self {
                 id: Uuid::new_v4(),
-                paused: false,
                 extra: Some(json!({"test":"dataset"})),
             }
         }
@@ -719,7 +738,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.dataset.id, plan_param.dataset.id);
-        assert_eq!(result.dataset.paused, plan_param.dataset.paused);
+        assert_eq!(result.dataset.paused, false);
         assert_eq!(result.dataset.extra, plan_param.dataset.extra);
         assert_eq!(result.dataset.modified_by, username);
 
@@ -727,7 +746,7 @@ mod tests {
             result.dataset,
             Dataset {
                 id: plan_param.dataset.id,
-                paused: plan_param.dataset.paused,
+                paused: false,
                 extra: plan_param.dataset.extra,
                 modified_by: username.to_string(),
                 modified_date: trim_to_microseconds(modified_date),
@@ -753,7 +772,6 @@ mod tests {
         // Test: Can we update an existing dataset?
         let updated_dataset_param = DatasetParam {
             id: plan_param.dataset.id,
-            paused: true,
             extra: Some(json!({"updated":true})),
         };
 
@@ -772,7 +790,7 @@ mod tests {
             result.dataset,
             Dataset {
                 id: updated_plan_param.dataset.id,
-                paused: true,
+                paused: false,
                 extra: Some(json!({"updated":true})),
                 modified_by: username.to_string(),
                 modified_date: trim_to_microseconds(modified_date),

--- a/src/model.rs
+++ b/src/model.rs
@@ -1206,7 +1206,7 @@ mod tests {
 
         // Test: Can we pause a plan?
         let result = plan.paused(&mut tx, true, username, modified_date).await;
-        
+
         assert!(result.is_ok());
         assert_eq!(plan.dataset.paused, true);
     }
@@ -1235,7 +1235,7 @@ mod tests {
 
         // Test: Can we unpause a plan?
         let result = plan.paused(&mut tx, false, username, modified_date).await;
-        
+
         assert!(result.is_ok());
         assert_eq!(plan.dataset.paused, false);
     }
@@ -1261,7 +1261,7 @@ mod tests {
 
         // Test: Do we get an error when trying to set pause state to current state?
         let result = plan.paused(&mut tx, false, username, modified_date).await;
-        
+
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -1272,7 +1272,7 @@ mod tests {
         plan.paused(&mut tx, true, username, modified_date)
             .await
             .unwrap();
-        
+
         let result = plan.paused(&mut tx, true, username, modified_date).await;
         assert!(result.is_err());
         assert!(matches!(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints to pause and unpause plans by dataset ID.
  * Plans can now be explicitly paused or unpaused, with changes reflected in the API.

* **Bug Fixes**
  * Improved error handling for cases where a dataset is already in the requested pause state.

* **Refactor**
  * The paused state is now managed internally and is no longer settable via input parameters.
  * Test cases updated to reflect changes in pause state handling.
  * Dataset insertion and updates now default to unpaused, with pause state updated explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->