### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/14](https://github.com/adelg003/fletcher/security/code-scanning/14)

To fix the problem, add a `permissions` key at the top level of the workflow file (just after the `name:` and before or after the `on:` block). This will apply the specified permissions to all jobs in the workflow unless overridden at the job level. Since the jobs in this workflow only need to check out code and run commands, the minimal required permission is `contents: read`. This change does not affect the existing functionality of the workflow and adheres to the principle of least privilege.

**Steps:**
- Insert a `permissions:` block with `contents: read` at the root level of `.github/workflows/rust.yaml`, after the `name:` line and before or after the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
