### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/15](https://github.com/adelg003/fletcher/security/code-scanning/15)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/rust.yaml`. The block should be placed at the top level of the workflow, so it applies to all jobs unless overridden. Since none of the jobs require write access to repository contents or other resources, the minimal required permission is `contents: read`. This change should be made immediately after the `name:` and before the `on:` block (typically after line 1 or 2). No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
