### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,4 +1,6 @@
 name: Trivy
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/13](https://github.com/adelg003/fletcher/security/code-scanning/13)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the jobs only check out code and run scans, they only need `contents: read`. The best way to do this is to add the `permissions` block at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs. No changes to the jobs themselves are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
