### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,4 +1,6 @@
 name: Python
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/12](https://github.com/adelg003/fletcher/security/code-scanning/12)

To fix the problem, add an explicit `permissions` block to the workflow. The best way is to add it at the root level, so it applies to all jobs unless overridden. Since all jobs only need to read repository contents, set `contents: read` as the minimal required permission. This change should be made at the top of the workflow file, immediately after the `name` field and before the `on` field. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
