### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,4 +1,6 @@
 name: Trivy
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/11](https://github.com/adelg003/fletcher/security/code-scanning/11)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/trivy.yaml`. The block should be placed at the root level (above `jobs:`) to apply to all jobs, unless a job requires different permissions. Since the jobs only need to read repository contents (for `actions/checkout`), the minimal required permission is `contents: read`. No other permissions are needed for the steps shown. Add the following block after the `name:` and before the `on:` section:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
