### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/10](https://github.com/adelg003/fletcher/security/code-scanning/10)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the top level of the workflow, so it applies to all jobs unless overridden. Since none of the jobs in this workflow require write access to the repository, the minimal required permission is `contents: read`. This will ensure the `GITHUB_TOKEN` only has read access to repository contents, adhering to the principle of least privilege. The change should be made at the top of the file, after the `name` field and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
