### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/9](https://github.com/adelg003/fletcher/security/code-scanning/9)

To fix the problem, add a `permissions` block at the top level of the workflow file (`.github/workflows/rust.yaml`), just below the `name` and before the `on` key. This block should specify the minimal permissions required for the workflow to function. Since none of the jobs in this workflow require write access to the repository, the best practice is to set `contents: read`, which allows jobs to read repository contents but not modify them. This change will apply to all jobs in the workflow unless a job explicitly overrides the permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
