### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,4 +1,6 @@
 name: Python
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/8](https://github.com/adelg003/fletcher/security/code-scanning/8)

To fix the problem, add a `permissions` block to the workflow file to explicitly restrict the `GITHUB_TOKEN` permissions. The most secure and minimal setting for workflows that only need to check out code and run local commands is `contents: read`. This can be set at the top level of the workflow file, which will apply to all jobs unless overridden. The change should be made by inserting the following block after the `name` field and before the `on` field:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
