### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,5 +1,8 @@
 name: Docker
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/7](https://github.com/adelg003/fletcher/security/code-scanning/7)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the jobs only need to check out code and do not perform any write operations, the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (for each job). The best approach is to add the following block near the top of the workflow file, after the `name` and before `on`, to apply to all jobs:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed. Only the YAML file needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
