### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/6](https://github.com/adelg003/fletcher/security/code-scanning/6)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the least privilege required for the jobs. Since all jobs in this workflow only need to read repository contents (for checking, formatting, testing, and auditing), you should set `contents: read` at the workflow level. This will apply to all jobs unless a job overrides it with its own `permissions` block. The change should be made at the top level of the workflow file, immediately after the `name:` and before the `on:` block, to ensure it applies globally.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
