### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,4 +1,6 @@
 name: Python
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/5](https://github.com/adelg003/fletcher/security/code-scanning/5)

To fix the problem, you should add an explicit `permissions` block to the workflow. Since all jobs in this workflow only need read access to repository contents (to check out code and run checks), you can add the following block at the top level of the workflow (just below the `name:` and before `on:`). This will apply the least privilege required to all jobs, ensuring the GITHUB_TOKEN only has read access to repository contents. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
