### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/4](https://github.com/adelg003/fletcher/security/code-scanning/4)

To fix the problem, add a `permissions` block at the top level of the workflow (just after the `name:` and before or after `on:`), specifying the minimal required permissions. For this workflow, which only checks out code and runs tests/linters, `contents: read` is sufficient. This will ensure that the `GITHUB_TOKEN` used by all jobs in this workflow has only read access to repository contents, adhering to the principle of least privilege. No changes to the jobs themselves are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
