### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,4 +1,6 @@
 name: Docker
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/3](https://github.com/adelg003/fletcher/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file. Since none of the jobs or steps require write access to repository contents, the minimal permission required is `contents: read`. This block should be added at the root level of the workflow (just below the `name:` and before `on:`), so it applies to all jobs unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
