### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -1,4 +1,6 @@
 name: Markdown
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/2](https://github.com/adelg003/fletcher/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum required. Since the workflow only checks out code and runs local linting tools, it does not need any write permissions. The minimal required permission is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job needs different permissions.  
**Change:**  
- Add a `permissions:` block with `contents: read` at the top level of `.github/workflows/markdown.yaml`, just after the `name:` line and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
