### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,4 +1,6 @@
 name: Python
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/1](https://github.com/adelg003/fletcher/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the jobs only check out code and run local commands, they only require read access to repository contents. The best way to do this is to add a `permissions: contents: read` block at the top level of the workflow (just after the `name:` and before `on:`), which will apply to all jobs unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
