### PR TITLE
Potential fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,9 +2,6 @@ name: Docker
 permissions:
   contents: read
 
-permissions:
-  contents: read
-
 on:
   pull_request:
     branches:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,4 +1,6 @@
 name: Docker
+permissions:
+  contents: read
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,5 +1,8 @@
 name: Docker
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -1,4 +1,6 @@
 name: Markdown
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,4 +1,6 @@
 name: Python
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,4 +1,6 @@
 name: Trivy
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adelg003/fletcher/security/code-scanning/15](https://github.com/adelg003/fletcher/security/code-scanning/15)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/*.yaml`. The block should be placed at the top level of the workflow, so it applies to all jobs unless overridden. Since none of the jobs require write access to repository contents or other resources, the minimal required permission is `contents: read`. This change should be made immediately after the `name:` and before the `on:` block (typically after line 1 or 2). No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Hardened CI by setting the workflow token to read-only for repository contents across all pipelines (e.g., Docker, Markdown checks, Python, Rust, Trivy).
  * No changes to triggers, jobs, or steps; build, test, and scanning behavior remains the same.
  * Aligns workflows with least-privilege best practices without impacting end-user functionality. Improves security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->